### PR TITLE
Replace gha set-output with env vars

### DIFF
--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -55,7 +55,7 @@ jobs:
           # then the last 3 digits of the total cherry-picks
           # i.e. if there are 10 cherry-picks total, the last 3 digits would be 010
           CHERRY_PICK_BRANCH=amp-release-${AMP_VERSION:0:10}${NEW_CP_COUNT: -3}
-          echo "::set-output name=branch::${CHERRY_PICK_BRANCH}"
+          echo "branch=${CHERRY_PICK_BRANCH}" >> $GITHUB_OUTPUT
 
       - name: Set git config
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         id: get-diff
         run: |
           DIFF=$(git diff --name-only --diff-filter=ACMRT ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | xargs)
-          echo "::set-output name=diff::${DIFF}"
+          echo "diff=${DIFF}" >> $GITHUB_OUTPUT
 
       - name: Run Prettier and ESLint
         run: |

--- a/.github/workflows/promote-lts.yml
+++ b/.github/workflows/promote-lts.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - name: Get day of the month
         id: day
-        run: echo "::set-output name=day::$(date +%d)"
+        run: echo "day=$(date +%d)" >> $GITHUB_OUTPUT
 
   promote-lts:
     needs: get-day


### PR DESCRIPTION
`set-output` will be deprecated in May 2023 - https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/